### PR TITLE
@sirutils/builder windows support ?

### DIFF
--- a/tools/builder/src/actions/build.ts
+++ b/tools/builder/src/actions/build.ts
@@ -46,8 +46,11 @@ export const build = async <T extends Sirutils.Builder.AnyFlags>(
       $`bun x tsc --project ./tsconfig.json --outDir ${options.generated.tmpDistPath}`,
     ])
 
+    // Recursive flag my differ according to platfom
+    const recursiveFlag = options.platform === "win32" ? "R" : "r"
+
     if (cli.flags.entrypoints.some(entrypoint => entrypoint.includes('src'))) {
-      await $`cp -r ${options.generated.tmpDistPath}/src/* ${options.generated.distPath}`
+      await $`cp -${recursiveFlag} ${options.generated.tmpDistPath}/src/* ${options.generated.distPath}`
     }
 
     const otherEntrypoints = cli.flags.entrypoints.filter(entrypoint => !entrypoint.includes('src'))
@@ -57,7 +60,7 @@ export const build = async <T extends Sirutils.Builder.AnyFlags>(
         otherEntrypoints.map(otherEntrypoint => {
           const dirName = otherEntrypoint.split('/')[0]
 
-          return $`cp -r ${options.generated.tmpDistPath}/${dirName}/* ${options.generated.distPath}/${dirName}`
+          return $`cp -${recursiveFlag} ${options.generated.tmpDistPath}/${dirName}/* ${options.generated.distPath}/${dirName}`
         })
       )
     }

--- a/tools/builder/src/actions/build.ts
+++ b/tools/builder/src/actions/build.ts
@@ -1,4 +1,4 @@
-import { $ } from 'bun'
+import { $, type BuildOutput } from 'bun'
 import type { Result } from 'meow'
 import ora from 'ora'
 
@@ -11,14 +11,38 @@ export const build = async <T extends Sirutils.Builder.AnyFlags>(
   const message = ora(`starting bundler at ${options.generated.projectName}`).start()
 
   try {
+    /* 
+     * Building by dividing into groups of source files
+     * for dont get any Bun error on Windows 
+     * because of "index out of bounds"
+     *
+     * This method also increase building speed
+     */
+    const builds: Promise<BuildOutput>[] = []
+
+    options.generated.entryPaths.forEach((_path, index, paths) => {
+      // Converting index to normal for algorithm logic
+      const normal = index + 1
+
+      // Building by group of 5 or less source files
+      if (normal % 5 === 0 || index === paths.length - (paths.length % 5)) {
+        const pathsStartIndex = normal - (normal % 5 || 5)
+        const entrypoints = paths.slice(pathsStartIndex, normal)
+
+        builds.push(
+          Bun.build({
+            ...options.bundle,
+            entrypoints: [...entrypoints],
+            external: options.generated.externals,
+            outdir: options.generated.tmpDistPath,
+            root: cli.flags.cwd,
+          })
+        )
+      }
+    })
+
     await Promise.all([
-      Bun.build({
-        ...options.bundle,
-        entrypoints: options.generated.entryPaths,
-        external: options.generated.externals,
-        outdir: options.generated.tmpDistPath,
-        root: cli.flags.cwd,
-      }),
+      ...builds,
       $`bun x tsc --project ./tsconfig.json --outDir ${options.generated.tmpDistPath}`,
     ])
 

--- a/tools/builder/src/definitions/builder.ts
+++ b/tools/builder/src/definitions/builder.ts
@@ -22,6 +22,7 @@ declare global {
 
       interface CustomOptions {}
       interface BaseOptions<T extends Sirutils.Builder.AnyFlags> {
+        platform: string
         helpMessages: {
           usage: string[]
           commands: string[]

--- a/tools/builder/src/utils/builder.ts
+++ b/tools/builder/src/utils/builder.ts
@@ -50,13 +50,16 @@ export const createBuilder = <T extends Sirutils.Builder.AnyFlags>(
       externals.push(...allDependencies)
     }
 
+    // Path delimiter of file path may differ on different platform
+    const pathDelimiter = config.platform === "win32" ? "\\" : "/"
+
     mergedConfig.generated = {
       pkg,
       projectName: cli.flags.cwd.split('/').slice(-2).join('/'),
       distPath: path.join(cli.flags.cwd, cli.flags.outdir),
       tmpDistPath: path.join(
         os.tmpdir(),
-        `sirutils/${cli.flags.cwd.split('/').slice(-2).join('/')}/${Date.now()}`
+        `sirutils/${cli.flags.cwd.split(pathDelimiter).slice(-2).join(pathDelimiter)}/${Date.now()}`
       ),
       entryPaths: cli.flags.entrypoints.reduce((acc, curr) => {
         const glob = new Glob(curr)

--- a/tools/builder/src/utils/config.ts
+++ b/tools/builder/src/utils/config.ts
@@ -1,6 +1,8 @@
 import { helpMessages } from './help-message'
+import os from 'node:os'
 
 export const config = {
+  platform: os.platform(),
   helpMessages,
   bundle: {
     entrypoints: ['src/**/*.ts'],


### PR DESCRIPTION
Path delimiter is fixed, it's according to platform
Source files are built group by group

And commit types is changed to relevant types